### PR TITLE
nix: install font files to share/fonts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,4 +18,4 @@ jobs:
           repo_token: '${{ secrets.GITHUB_TOKEN }}'
           automatic_release_tag: latest
           prerelease: false
-          files: result/*
+          files: result/share/fonts/*/*

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,11 @@
           src = self;
           buildInputs = [ pkgs.fontforge-fonttools ];
           buildPhase = "fontforge -lang=ff -c 'Open($1); Generate($2); Generate($3)' Derani.sfd Derani.otf Derani.woff2";
-          installPhase = "mkdir $out && install -t $out Derani.otf Derani.woff2";
+          installPhase = ''
+            mkdir -p $out/share/fonts/{opentype,woff2}
+            mv Derani.otf   $out/share/fonts/opentype
+            mv Derani.woff2 $out/share/fonts/woff2
+          '';
         };
       in {
         defaultPackage = derani-fonts;


### PR DESCRIPTION
… so that when installed via a nixos configuration's `fonts.fonts` or via home-manager, they end up in the right place.